### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to update the schedule interval for dependency updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R11): Changed the `interval` for `github-actions` and `devcontainers` from "monthly" to "weekly".